### PR TITLE
Add Symfony 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.1.3",
-        "symfony/config": "^3.4 || ^4.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0",
-        "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/validator": "^3.4 || ^4.0"
+        "symfony/config": "^3.4 || ^4.0 || ^5.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
+        "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0",
+        "symfony/validator": "^3.4 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -28,8 +28,9 @@
         }
     },
     "require-dev": {
-        "symfony/var-dumper": "^3.4 || ^4.0",
-        "symfony/phpunit-bridge": "^3.4 || ^4.0",
-        "symfony/translation": "^3.4 || ^4.0"
+        "dg/bypass-finals": "^1.1",
+        "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0",
+        "symfony/translation": "^3.4 || ^4.0 || ^5.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="./vendor/autoload.php"
@@ -24,4 +24,8 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+
+    <extensions>
+        <extension class="Adamsafr\FormRequestBundle\Tests\PHPUnit\Hooks\BypassFinalHook"/>
+    </extensions>
 </phpunit>

--- a/tests/PHPUnit/Hooks/BypassFinalHook.php
+++ b/tests/PHPUnit/Hooks/BypassFinalHook.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Adamsafr\FormRequestBundle\Tests\PHPUnit\Hooks;
+
+use DG\BypassFinals;
+use PHPUnit\Runner\BeforeTestHook;
+
+/**
+ * Class BypassFinalHook
+ *
+ * Borrowed from: https://www.tomasvotruba.com/blog/2019/03/28/how-to-mock-final-classes-in-phpunit/
+ * Allows mocking SF final events introduced in SF 5+
+ */
+final class BypassFinalHook implements BeforeTestHook
+{
+    public function executeBeforeTest(string $test): void
+    {
+        BypassFinals::enable();
+    }
+}


### PR DESCRIPTION
From the article mentioned in the Hook class, adds dg/bypass-finals to keep the event mocking. In Symfony 5, the kernel events are marked as final. All tests pass with this lib without any other changes. PHPUnit 8 is needed for the class, but I think the default with SF 5 + phpunit-bridge is 8.3 (that is what was installed locally for me).